### PR TITLE
Add bmp image support

### DIFF
--- a/src/app/services/dragdrop.service.ts
+++ b/src/app/services/dragdrop.service.ts
@@ -7,7 +7,7 @@ import * as fs from "fs";
 @Injectable()
 export class DragDropService {
 
-    private readonly IMAGE_EXTENSIONS: Array<string> = ["png", "jpeg", "jpg", "gif", "svg"];
+    private readonly IMAGE_EXTENSIONS: Array<string> = ["png", "jpeg", "jpg", "bmp", "gif", "svg"];
 
     private fs: typeof fs;
 


### PR DESCRIPTION
I've taken a look at issue #66 and it appears that the issue was that on Windows, the picture gets saved as a .bmp when drag and dropping an image. This fixes it


Fix #66 